### PR TITLE
Related with queries (i.e. all provinces in the Netherlands)

### DIFF
--- a/data/related.cypher
+++ b/data/related.cypher
@@ -9,7 +9,6 @@ WITH ids, coalesce(concepts, ids) AS matched
 
 // find paths
 MATCH (found:_) «directionFrom» [:«relations»|`=`|`=i` * 3 .. 9] «directionTo» matched
-//MATCH shortestPath((found:_) «directionFrom» [:«relations»|`=`|`=i` * .. 6] «directionTo» matched)
 
 WHERE NOT found:_Rel AND NOT found:`=`
 RETURN DISTINCT found.id AS id

--- a/data/related.cypher
+++ b/data/related.cypher
@@ -1,0 +1,16 @@
+// find target nodes
+MATCH (ids:_) WHERE ids.id IN {ids}
+
+// find corresponding equivalence classes (ECs)
+OPTIONAL MATCH ids <-[:`=`]- (concepts:`=`)
+
+// choose the right node (EC if there, otherwise only member)
+WITH ids, coalesce(concepts, ids) AS matched
+
+// find paths
+MATCH (found:_) «directionFrom» [:«relations»|`=`|`=i` * 3 .. 9] «directionTo» matched
+//MATCH shortestPath((found:_) «directionFrom» [:«relations»|`=`|`=i` * .. 6] «directionTo» matched)
+
+WHERE NOT found:_Rel AND NOT found:`=`
+RETURN DISTINCT found.id AS id
+LIMIT 100

--- a/data/shortest-path.cypher
+++ b/data/shortest-path.cypher
@@ -1,13 +1,13 @@
-// find source, target nodes
+// find source and target nodes
 MATCH (m:_) WHERE m.id IN {idsFrom}
 MATCH (n:_) WHERE n.id IN {idsTo}
 
-// find corresponding equivalence classes
+// find corresponding equivalence classes (ECs)
 OPTIONAL MATCH m <-[:`=`]- (mConcept:`=`)
 OPTIONAL MATCH n <-[:`=`]- (nConcept:`=`)
 
 // choose the right node (EC if there, otherwise only member)
-WITH m, coalesce(nConcept, n) AS to,
+WITH coalesce(nConcept, n) AS to,
      coalesce(mConcept, m) AS from
 
 // ensure we have a path

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ app.get('/search',
           message: err
         });
       } else {
-        results = jsonld(geojson(results), req.query);
+        results = jsonld(geojson(results, req.processedQuery), req.processedQuery);
         res.send(results);
       }
     });

--- a/lib/format-schema-errors.js
+++ b/lib/format-schema-errors.js
@@ -5,11 +5,7 @@ module.exports = function(errors) {
 };
 
 function formatSchemaError(error) {
-  if (error.message === 'no (or more than one) schemas match') {
-    return 'Please supply exactly one search parameter: `q`, `uri`, `name` or `id`';
-  } else {
-    // Lelijk but nou en!
-    var field = error.field.replace('data.', '').replace('data["', '').replace('"]', '');
-    return util.format('`%s` %s', field, error.message);
-  }
+  // Lelijk but nou en!
+  var field = error.field.replace('data.', '').replace('data["', '').replace('"]', '');
+  return util.format('`%s` %s', field, error.message);
 }

--- a/lib/geojson.js
+++ b/lib/geojson.js
@@ -28,7 +28,7 @@ function idOrUri(obj) {
 }
 
 // Turns output from Histograph Neo4j Plugin into GeoJSON!
-module.exports = function(json) {
+module.exports = function(json, query) {
   if (json && json.length > 0) {
     return {
       type: 'FeatureCollection',
@@ -78,16 +78,21 @@ module.exports = function(json) {
           return pit;
         });
 
+        var geometry;
+        if (query.geometry) {
+          geometry = {
+            type: 'GeometryCollection',
+            geometries: geometries
+          };
+        }
+
         return {
           type: 'Feature',
           properties: {
             type: type,
             pits: pits
           },
-          geometry: {
-            type: 'GeometryCollection',
-            geometries: geometries
-          }
+          geometry: geometry
         };
       })
     };

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -14,12 +14,16 @@ if (config.neo4j.user && config.neo4j.password) {
 var graphDb = new neo4j.GraphDatabase(neo4jUrl);
 
 var shortestPathQuery = fs.readFileSync(path.join(__dirname, '..', 'data', 'shortest-path.cypher'), {encoding: 'utf8'});
+var relatedQuery = fs.readFileSync(path.join(__dirname, '..', 'data', 'related.cypher'), {encoding: 'utf8'});
 
-exports.shortestPath = function(idsFrom, idsTo, relations, callback) {
-
-  var query = shortestPathQuery.replace('«relations»', relations.map(function(relation) {
+function replaceRelations(query, relations) {
+  return query.replace('«relations»', relations.map(function(relation) {
     return '`' + relation + '`';
   }).join('|'));
+}
+
+exports.shortestPath = function(idsFrom, idsTo, relations, callback) {
+  var query = replaceRelations(shortestPathQuery, relations);
 
   graphDb.cypher({
     query: query,
@@ -39,7 +43,33 @@ exports.shortestPath = function(idsFrom, idsTo, relations, callback) {
   });
 };
 
-exports.expand = function(ids, hairs, callback) {
+exports.related = function(ids, relations, direction, callback) {
+  var query = replaceRelations(relatedQuery, relations);
+
+  if (direction === 'from') {
+    query = query.replace('«directionFrom»', '-').replace('«directionTo»', '->');
+  } else if (direction === 'to') {
+    query = query.replace('«directionFrom»', '<-').replace('«directionTo»', '-');
+  }
+
+  graphDb.cypher({
+    query: query,
+    params: {
+      ids: ids
+    }
+  }, function(err, results) {
+    var ids;
+    if (results) {
+      ids = results.map(function(result) {
+        return result.id;
+      });
+    }
+
+    callback(err, ids);
+  });
+};
+
+exports.expand = function(ids, callback) {
   var reqOptions = {
     uri: neo4jUrl + '/histograph/expand',
     method: 'POST',

--- a/lib/jsonld.js
+++ b/lib/jsonld.js
@@ -25,18 +25,11 @@ module.exports = function(geojson, query) {
         return pit;
       });
 
-      if (query.geometry) {
-        return {
-          type: feature.type,
-          properties: feature.properties,
-          geometry: feature.geometry
-        };
-      } else {
-        return {
-          type: feature.type,
-          properties: feature.properties
-        };
-      }
+      return {
+        type: feature.type,
+        properties: feature.properties,
+        geometry: feature.geometry
+      };
     })
   };
 };

--- a/lib/params.js
+++ b/lib/params.js
@@ -19,9 +19,11 @@ function preprocessParams(query, substructure, processedQuery, prefix) {
 
   Object.keys(substructure).forEach(function(param) {
     var pParam = prefix + param;
+    var type = substructure[param].type;
     if (query[pParam]) {
-      var type = substructure[param].type;
       processedQuery[pParam] = preprocessParam(param, type, query[pParam].trim());
+    } else if (type === 'boolean') {
+      processedQuery[pParam] = substructure[param].default || false;
     }
   });
 }

--- a/lib/query.js
+++ b/lib/query.js
@@ -18,24 +18,49 @@ function esParams(query, includeRelated) {
   return params;
 }
 
+function related(esParams, relations, direction, callback) {
+  _([esParams])
+    .nfcall([])
+    .series()
+    .errors(function(err) {
+      callback(err);
+    })
+    .apply(function(ids) {
+      graph.related(ids, relations, direction, function(err, ids) {
+        if (err) {
+          callback(err);
+        } else {
+          graph.expand(ids, function(err, concepts) {
+            callback(err, concepts);
+          });
+        }
+      });
+    });
+}
+
 module.exports = function(query, callback) {
   var esQueryFrom = elasticsearch.searchQuery(esParams(query, false));
+  var esQueryTo = elasticsearch.searchQuery(esParams(query, true));
 
-  if (!query.related) {
-    _([esQueryFrom])
-      .nfcall([])
-      .series()
-      .errors(function(err) {
-        callback(err);
-      })
-      .sequence()
-      .toArray(function(ids) {
-        graph.expand(ids, [], function(err, concepts) {
-          callback(err, concepts);
-        });
-      });
-  } else {
-    var esQueryTo = elasticsearch.searchQuery(esParams(query, true));
+  // Query types:
+  //
+  // 1. [q, uri, name, id]:
+  //      Elasticsearch -> Expand
+  //
+  // 2. [q, uri, name, id] && related:
+  //      Elasticsearch -> Related -> Expand
+  //
+  // 3. [q, uri, name, id] && related && [related.q, related.uri, related.name, related.id]:
+  //      (Elasticsearch, Elasticsearch) -> Shortest path -> Expand
+  //
+  // 4.                       related && [related.q, related.uri, related.name, related.id]:
+  //      Elasticsearch -> Related -> Expand
+
+  var hasSearchParam = query.q || query.id || query.uri || query.name;
+  var hasRelatedParam = query.related;
+  var hasRelatedSearchParam = query['related.q'] || query['related.id'] || query['related.uri'] || query['related.name'];
+
+  if (hasSearchParam && hasRelatedParam && hasRelatedSearchParam) {
     _([esQueryFrom, esQueryTo])
       .nfcall([])
       .parallel(2)
@@ -47,11 +72,36 @@ module.exports = function(query, callback) {
           if (err) {
             callback(err);
           } else {
-            graph.expand(ids, [], function(err, concepts) {
+            graph.expand(ids, function(err, concepts) {
               callback(err, concepts);
             });
           }
         });
       });
+
+  } else if (hasSearchParam && hasRelatedParam) {
+    related(esQueryFrom, query.related, 'to', callback);
+
+  } else if (hasRelatedParam && hasRelatedSearchParam) {
+    related(esQueryTo, query.related, 'from', callback);
+
+  } else if (hasSearchParam) {
+    _([esQueryFrom])
+      .nfcall([])
+      .series()
+      .errors(function(err) {
+        callback(err);
+      })
+      .sequence()
+      .toArray(function(ids) {
+        graph.expand(ids, function(err, concepts) {
+          callback(err, concepts);
+        });
+      });
+
+  } else {
+
+    callback('Please supply at least one search parameter: `q`, `uri`, `name` or `id`');
+
   }
 };

--- a/lib/structure-to-schema.js
+++ b/lib/structure-to-schema.js
@@ -99,17 +99,6 @@ function addToQuerySchema(schema, structure, prefix) {
     schema.properties[related] = arrayProperty(structure.related);
     addToQuerySchema(schema, structure, related);
   }
-
-  // oneOf
-  if (!prefix) {
-    Object.keys(structure.search).forEach(function(param) {
-      schema.oneOf.push({
-        required: [
-          param
-        ]
-      });
-    });
-  }
 }
 
 module.exports = function(structure) {


### PR DESCRIPTION
Added support for two extra query types:
1. `[q, uri, name, id]`:
   - Elasticsearch → Expand
2. `[q, uri, name, id] && related` (**new**):
   - Elasticsearch → Related → Expand
3. `[q, uri, name, id] && related && [related.q, related.uri, related.name, related.id]`:
   - (Elasticsearch, Elasticsearch) → Shortest path → Expand
4. `related && [related.q, related.uri, related.name, related.id]` (**new**):
   - Elasticsearch → Related → Expand
